### PR TITLE
移除Lombok依赖，手动实现所有getter、setter和构造函数，添加SQL文件

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,12 +13,12 @@
     <version>0.0.1-SNAPSHOT</version>
     <name>Linux.do CDK Distribution System</name>
     <description>A CDK distribution system for Linux.do forum</description>
-    
+
     <properties>
         <java.version>11</java.version>
         <jjwt.version>0.11.5</jjwt.version>
     </properties>
-    
+
     <dependencies>
         <!-- Spring Boot Starters -->
         <dependency>
@@ -41,14 +41,14 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
         </dependency>
-        
+
         <!-- Database -->
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
             <version>8.0.33</version>
         </dependency>
-        
+
         <!-- JWT -->
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
@@ -67,24 +67,19 @@
             <version>${jjwt.version}</version>
             <scope>runtime</scope>
         </dependency>
-        
+
         <!-- OAuth2 Client -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-oauth2-client</artifactId>
         </dependency>
-        
+
         <!-- Utilities -->
-        <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <optional>true</optional>
-        </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
-        
+
         <!-- Test -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -96,7 +91,7 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
-        
+
         <!-- Dev Tools -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -105,20 +100,13 @@
             <optional>true</optional>
         </dependency>
     </dependencies>
-    
+
     <build>
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <configuration>
-                    <excludes>
-                        <exclude>
-                            <groupId>org.projectlombok</groupId>
-                            <artifactId>lombok</artifactId>
-                        </exclude>
-                    </excludes>
-                </configuration>
+
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/linuxdo/cdkdistribution/model/Cdk.java
+++ b/src/main/java/com/linuxdo/cdkdistribution/model/Cdk.java
@@ -1,20 +1,13 @@
 package com.linuxdo.cdkdistribution.model;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Entity
 @Table(name = "cdk")
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class Cdk {
 
     @Id
@@ -41,4 +34,161 @@ public class Cdk {
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
+
+    // 默认构造函数
+    public Cdk() {
+    }
+
+    // 全参数构造函数
+    public Cdk(Long id, CdkActivity activity, String code, Boolean isClaimed, User claimedBy,
+              LocalDateTime claimedAt, LocalDateTime createdAt) {
+        this.id = id;
+        this.activity = activity;
+        this.code = code;
+        this.isClaimed = isClaimed;
+        this.claimedBy = claimedBy;
+        this.claimedAt = claimedAt;
+        this.createdAt = createdAt;
+    }
+
+    // Builder模式的静态内部类
+    public static class CdkBuilder {
+        private Long id;
+        private CdkActivity activity;
+        private String code;
+        private Boolean isClaimed;
+        private User claimedBy;
+        private LocalDateTime claimedAt;
+        private LocalDateTime createdAt;
+
+        public CdkBuilder id(Long id) {
+            this.id = id;
+            return this;
+        }
+
+        public CdkBuilder activity(CdkActivity activity) {
+            this.activity = activity;
+            return this;
+        }
+
+        public CdkBuilder code(String code) {
+            this.code = code;
+            return this;
+        }
+
+        public CdkBuilder isClaimed(Boolean isClaimed) {
+            this.isClaimed = isClaimed;
+            return this;
+        }
+
+        public CdkBuilder claimedBy(User claimedBy) {
+            this.claimedBy = claimedBy;
+            return this;
+        }
+
+        public CdkBuilder claimedAt(LocalDateTime claimedAt) {
+            this.claimedAt = claimedAt;
+            return this;
+        }
+
+        public CdkBuilder createdAt(LocalDateTime createdAt) {
+            this.createdAt = createdAt;
+            return this;
+        }
+
+        public Cdk build() {
+            return new Cdk(id, activity, code, isClaimed, claimedBy, claimedAt, createdAt);
+        }
+    }
+
+    // 静态builder方法
+    public static CdkBuilder builder() {
+        return new CdkBuilder();
+    }
+
+    // Getter和Setter方法
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public CdkActivity getActivity() {
+        return activity;
+    }
+
+    public void setActivity(CdkActivity activity) {
+        this.activity = activity;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public Boolean getIsClaimed() {
+        return isClaimed;
+    }
+
+    public void setIsClaimed(Boolean isClaimed) {
+        this.isClaimed = isClaimed;
+    }
+
+    public User getClaimedBy() {
+        return claimedBy;
+    }
+
+    public void setClaimedBy(User claimedBy) {
+        this.claimedBy = claimedBy;
+    }
+
+    public LocalDateTime getClaimedAt() {
+        return claimedAt;
+    }
+
+    public void setClaimedAt(LocalDateTime claimedAt) {
+        this.claimedAt = claimedAt;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    // equals和hashCode方法
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Cdk cdk = (Cdk) o;
+        return Objects.equals(id, cdk.id) &&
+               Objects.equals(code, cdk.code);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, code);
+    }
+
+    // toString方法
+    @Override
+    public String toString() {
+        return "Cdk{" +
+                "id=" + id +
+                ", activity=" + (activity != null ? activity.getId() : null) +
+                ", code='" + code + '\'' +
+                ", isClaimed=" + isClaimed +
+                ", claimedBy=" + (claimedBy != null ? claimedBy.getId() : null) +
+                ", claimedAt=" + claimedAt +
+                ", createdAt=" + createdAt +
+                '}';
+    }
 }

--- a/src/main/java/com/linuxdo/cdkdistribution/model/CdkActivity.java
+++ b/src/main/java/com/linuxdo/cdkdistribution/model/CdkActivity.java
@@ -1,21 +1,14 @@
 package com.linuxdo.cdkdistribution.model;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Entity
 @Table(name = "cdk_activity")
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class CdkActivity {
 
     @Id
@@ -64,8 +57,283 @@ public class CdkActivity {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
+    // 默认构造函数
+    public CdkActivity() {
+    }
+
+    // 全参数构造函数
+    public CdkActivity(Long id, String title, String description, String usageGuide, Integer minTrustLevel,
+                      Integer totalCount, Integer remainingCount, LocalDateTime startTime, LocalDateTime endTime,
+                      Boolean isActive, Boolean isPublic, User creator, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.title = title;
+        this.description = description;
+        this.usageGuide = usageGuide;
+        this.minTrustLevel = minTrustLevel;
+        this.totalCount = totalCount;
+        this.remainingCount = remainingCount;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.isActive = isActive;
+        this.isPublic = isPublic;
+        this.creator = creator;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    // Builder模式的静态内部类
+    public static class CdkActivityBuilder {
+        private Long id;
+        private String title;
+        private String description;
+        private String usageGuide;
+        private Integer minTrustLevel;
+        private Integer totalCount;
+        private Integer remainingCount;
+        private LocalDateTime startTime;
+        private LocalDateTime endTime;
+        private Boolean isActive;
+        private Boolean isPublic;
+        private User creator;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+
+        public CdkActivityBuilder id(Long id) {
+            this.id = id;
+            return this;
+        }
+
+        public CdkActivityBuilder title(String title) {
+            this.title = title;
+            return this;
+        }
+
+        public CdkActivityBuilder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public CdkActivityBuilder usageGuide(String usageGuide) {
+            this.usageGuide = usageGuide;
+            return this;
+        }
+
+        public CdkActivityBuilder minTrustLevel(Integer minTrustLevel) {
+            this.minTrustLevel = minTrustLevel;
+            return this;
+        }
+
+        public CdkActivityBuilder totalCount(Integer totalCount) {
+            this.totalCount = totalCount;
+            return this;
+        }
+
+        public CdkActivityBuilder remainingCount(Integer remainingCount) {
+            this.remainingCount = remainingCount;
+            return this;
+        }
+
+        public CdkActivityBuilder startTime(LocalDateTime startTime) {
+            this.startTime = startTime;
+            return this;
+        }
+
+        public CdkActivityBuilder endTime(LocalDateTime endTime) {
+            this.endTime = endTime;
+            return this;
+        }
+
+        public CdkActivityBuilder isActive(Boolean isActive) {
+            this.isActive = isActive;
+            return this;
+        }
+
+        public CdkActivityBuilder isPublic(Boolean isPublic) {
+            this.isPublic = isPublic;
+            return this;
+        }
+
+        public CdkActivityBuilder creator(User creator) {
+            this.creator = creator;
+            return this;
+        }
+
+        public CdkActivityBuilder createdAt(LocalDateTime createdAt) {
+            this.createdAt = createdAt;
+            return this;
+        }
+
+        public CdkActivityBuilder updatedAt(LocalDateTime updatedAt) {
+            this.updatedAt = updatedAt;
+            return this;
+        }
+
+        public CdkActivity build() {
+            return new CdkActivity(id, title, description, usageGuide, minTrustLevel, totalCount, remainingCount,
+                                 startTime, endTime, isActive, isPublic, creator, createdAt, updatedAt);
+        }
+    }
+
+    // 静态builder方法
+    public static CdkActivityBuilder builder() {
+        return new CdkActivityBuilder();
+    }
+
+    // 判断活动是否可用
     public boolean isAvailable() {
         LocalDateTime now = LocalDateTime.now();
         return isActive && now.isAfter(startTime) && now.isBefore(endTime) && remainingCount > 0;
+    }
+
+    // Getter和Setter方法
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getUsageGuide() {
+        return usageGuide;
+    }
+
+    public void setUsageGuide(String usageGuide) {
+        this.usageGuide = usageGuide;
+    }
+
+    public Integer getMinTrustLevel() {
+        return minTrustLevel;
+    }
+
+    public void setMinTrustLevel(Integer minTrustLevel) {
+        this.minTrustLevel = minTrustLevel;
+    }
+
+    public Integer getTotalCount() {
+        return totalCount;
+    }
+
+    public void setTotalCount(Integer totalCount) {
+        this.totalCount = totalCount;
+    }
+
+    public Integer getRemainingCount() {
+        return remainingCount;
+    }
+
+    public void setRemainingCount(Integer remainingCount) {
+        this.remainingCount = remainingCount;
+    }
+
+    public LocalDateTime getStartTime() {
+        return startTime;
+    }
+
+    public void setStartTime(LocalDateTime startTime) {
+        this.startTime = startTime;
+    }
+
+    public LocalDateTime getEndTime() {
+        return endTime;
+    }
+
+    public void setEndTime(LocalDateTime endTime) {
+        this.endTime = endTime;
+    }
+
+    public Boolean getIsActive() {
+        return isActive;
+    }
+
+    public void setIsActive(Boolean isActive) {
+        this.isActive = isActive;
+    }
+
+    public Boolean getIsPublic() {
+        return isPublic;
+    }
+
+    public void setIsPublic(Boolean isPublic) {
+        this.isPublic = isPublic;
+    }
+
+    public User getCreator() {
+        return creator;
+    }
+
+    public void setCreator(User creator) {
+        this.creator = creator;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    // equals和hashCode方法
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CdkActivity that = (CdkActivity) o;
+        return Objects.equals(id, that.id) &&
+               Objects.equals(title, that.title) &&
+               Objects.equals(minTrustLevel, that.minTrustLevel) &&
+               Objects.equals(startTime, that.startTime) &&
+               Objects.equals(endTime, that.endTime);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, title, minTrustLevel, startTime, endTime);
+    }
+
+    // toString方法
+    @Override
+    public String toString() {
+        return "CdkActivity{" +
+                "id=" + id +
+                ", title='" + title + '\'' +
+                ", description='" + description + '\'' +
+                ", usageGuide='" + usageGuide + '\'' +
+                ", minTrustLevel=" + minTrustLevel +
+                ", totalCount=" + totalCount +
+                ", remainingCount=" + remainingCount +
+                ", startTime=" + startTime +
+                ", endTime=" + endTime +
+                ", isActive=" + isActive +
+                ", isPublic=" + isPublic +
+                ", creator=" + (creator != null ? creator.getId() : null) +
+                ", createdAt=" + createdAt +
+                ", updatedAt=" + updatedAt +
+                '}';
     }
 }

--- a/src/main/java/com/linuxdo/cdkdistribution/model/ClaimRecord.java
+++ b/src/main/java/com/linuxdo/cdkdistribution/model/ClaimRecord.java
@@ -1,19 +1,11 @@
 package com.linuxdo.cdkdistribution.model;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Entity
 @Table(name = "claim_record")
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class ClaimRecord {
 
     @Id
@@ -37,4 +29,146 @@ public class ClaimRecord {
 
     @Column(name = "ip_address")
     private String ipAddress;
+
+    // 默认构造函数
+    public ClaimRecord() {
+    }
+
+    // 全参数构造函数
+    public ClaimRecord(Long id, User user, CdkActivity activity, Cdk cdk, LocalDateTime claimedAt, String ipAddress) {
+        this.id = id;
+        this.user = user;
+        this.activity = activity;
+        this.cdk = cdk;
+        this.claimedAt = claimedAt;
+        this.ipAddress = ipAddress;
+    }
+
+    // Builder模式的静态内部类
+    public static class ClaimRecordBuilder {
+        private Long id;
+        private User user;
+        private CdkActivity activity;
+        private Cdk cdk;
+        private LocalDateTime claimedAt;
+        private String ipAddress;
+
+        public ClaimRecordBuilder id(Long id) {
+            this.id = id;
+            return this;
+        }
+
+        public ClaimRecordBuilder user(User user) {
+            this.user = user;
+            return this;
+        }
+
+        public ClaimRecordBuilder activity(CdkActivity activity) {
+            this.activity = activity;
+            return this;
+        }
+
+        public ClaimRecordBuilder cdk(Cdk cdk) {
+            this.cdk = cdk;
+            return this;
+        }
+
+        public ClaimRecordBuilder claimedAt(LocalDateTime claimedAt) {
+            this.claimedAt = claimedAt;
+            return this;
+        }
+
+        public ClaimRecordBuilder ipAddress(String ipAddress) {
+            this.ipAddress = ipAddress;
+            return this;
+        }
+
+        public ClaimRecord build() {
+            return new ClaimRecord(id, user, activity, cdk, claimedAt, ipAddress);
+        }
+    }
+
+    // 静态builder方法
+    public static ClaimRecordBuilder builder() {
+        return new ClaimRecordBuilder();
+    }
+
+    // Getter和Setter方法
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public CdkActivity getActivity() {
+        return activity;
+    }
+
+    public void setActivity(CdkActivity activity) {
+        this.activity = activity;
+    }
+
+    public Cdk getCdk() {
+        return cdk;
+    }
+
+    public void setCdk(Cdk cdk) {
+        this.cdk = cdk;
+    }
+
+    public LocalDateTime getClaimedAt() {
+        return claimedAt;
+    }
+
+    public void setClaimedAt(LocalDateTime claimedAt) {
+        this.claimedAt = claimedAt;
+    }
+
+    public String getIpAddress() {
+        return ipAddress;
+    }
+
+    public void setIpAddress(String ipAddress) {
+        this.ipAddress = ipAddress;
+    }
+
+    // equals和hashCode方法
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ClaimRecord that = (ClaimRecord) o;
+        return Objects.equals(id, that.id) &&
+               Objects.equals(user.getId(), that.user.getId()) &&
+               Objects.equals(activity.getId(), that.activity.getId()) &&
+               Objects.equals(cdk.getId(), that.cdk.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, user.getId(), activity.getId(), cdk.getId());
+    }
+
+    // toString方法
+    @Override
+    public String toString() {
+        return "ClaimRecord{" +
+                "id=" + id +
+                ", user=" + (user != null ? user.getId() : null) +
+                ", activity=" + (activity != null ? activity.getId() : null) +
+                ", cdk=" + (cdk != null ? cdk.getId() : null) +
+                ", claimedAt=" + claimedAt +
+                ", ipAddress='" + ipAddress + '\'' +
+                '}';
+    }
 }

--- a/src/main/java/com/linuxdo/cdkdistribution/model/User.java
+++ b/src/main/java/com/linuxdo/cdkdistribution/model/User.java
@@ -1,21 +1,14 @@
 package com.linuxdo.cdkdistribution.model;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Entity
 @Table(name = "users")
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
 public class User {
 
     @Id
@@ -41,4 +34,164 @@ public class User {
     @UpdateTimestamp
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
+
+    // 默认构造函数
+    public User() {
+    }
+
+    // 全参数构造函数
+    public User(Long id, String linuxDoId, String username, String avatar, Integer trustLevel,
+                LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.id = id;
+        this.linuxDoId = linuxDoId;
+        this.username = username;
+        this.avatar = avatar;
+        this.trustLevel = trustLevel;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    // Builder模式的静态内部类
+    public static class UserBuilder {
+        private Long id;
+        private String linuxDoId;
+        private String username;
+        private String avatar;
+        private Integer trustLevel;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+
+        public UserBuilder id(Long id) {
+            this.id = id;
+            return this;
+        }
+
+        public UserBuilder linuxDoId(String linuxDoId) {
+            this.linuxDoId = linuxDoId;
+            return this;
+        }
+
+        public UserBuilder username(String username) {
+            this.username = username;
+            return this;
+        }
+
+        public UserBuilder avatar(String avatar) {
+            this.avatar = avatar;
+            return this;
+        }
+
+        public UserBuilder trustLevel(Integer trustLevel) {
+            this.trustLevel = trustLevel;
+            return this;
+        }
+
+        public UserBuilder createdAt(LocalDateTime createdAt) {
+            this.createdAt = createdAt;
+            return this;
+        }
+
+        public UserBuilder updatedAt(LocalDateTime updatedAt) {
+            this.updatedAt = updatedAt;
+            return this;
+        }
+
+        public User build() {
+            return new User(id, linuxDoId, username, avatar, trustLevel, createdAt, updatedAt);
+        }
+    }
+
+    // 静态builder方法
+    public static UserBuilder builder() {
+        return new UserBuilder();
+    }
+
+    // Getter和Setter方法
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getLinuxDoId() {
+        return linuxDoId;
+    }
+
+    public void setLinuxDoId(String linuxDoId) {
+        this.linuxDoId = linuxDoId;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getAvatar() {
+        return avatar;
+    }
+
+    public void setAvatar(String avatar) {
+        this.avatar = avatar;
+    }
+
+    public Integer getTrustLevel() {
+        return trustLevel;
+    }
+
+    public void setTrustLevel(Integer trustLevel) {
+        this.trustLevel = trustLevel;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public void setUpdatedAt(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+
+    // equals和hashCode方法
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        User user = (User) o;
+        return Objects.equals(id, user.id) &&
+               Objects.equals(linuxDoId, user.linuxDoId) &&
+               Objects.equals(username, user.username) &&
+               Objects.equals(avatar, user.avatar) &&
+               Objects.equals(trustLevel, user.trustLevel);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, linuxDoId, username, avatar, trustLevel);
+    }
+
+    // toString方法
+    @Override
+    public String toString() {
+        return "User{" +
+                "id=" + id +
+                ", linuxDoId='" + linuxDoId + '\'' +
+                ", username='" + username + '\'' +
+                ", avatar='" + avatar + '\'' +
+                ", trustLevel=" + trustLevel +
+                ", createdAt=" + createdAt +
+                ", updatedAt=" + updatedAt +
+                '}';
+    }
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,49 @@
+-- 初始用户数据
+INSERT INTO users (linux_do_id, username, avatar, trust_level, created_at, updated_at)
+VALUES
+    ('admin123', '管理员', 'https://linux.do/user_avatar/linux.do/admin/240/1.png', 3, NOW(), NOW()),
+    ('user456', '普通用户', 'https://linux.do/user_avatar/linux.do/user/240/2.png', 1, NOW(), NOW()),
+    ('trusted789', '信任用户', 'https://linux.do/user_avatar/linux.do/trusted/240/3.png', 2, NOW(), NOW());
+
+-- 初始CDK活动数据
+INSERT INTO cdk_activity (title, description, usage_guide, min_trust_level, total_count, remaining_count, 
+                         start_time, end_time, is_active, is_public, creator_id, created_at, updated_at)
+VALUES
+    ('JetBrains全家桶激活码', 'JetBrains全系列IDE一年激活码，包括IntelliJ IDEA、PyCharm、WebStorm等。', 
+     '1. 打开任意JetBrains IDE\n2. 点击菜单 Help -> Register\n3. 选择 "Activation code"\n4. 粘贴激活码并点击激活', 
+     2, 10, 10, NOW(), DATE_ADD(NOW(), INTERVAL 30 DAY), TRUE, TRUE, 1, NOW(), NOW()),
+    
+    ('Windows 11专业版激活码', 'Windows 11专业版正版激活码，支持在线激活。', 
+     '1. 打开设置 -> 系统 -> 激活\n2. 点击"更改产品密钥"\n3. 输入激活码\n4. 点击"下一步"完成激活', 
+     1, 5, 5, NOW(), DATE_ADD(NOW(), INTERVAL 15 DAY), TRUE, TRUE, 1, NOW(), NOW()),
+    
+    ('Adobe Creative Cloud会员', 'Adobe Creative Cloud一年会员资格，包含Photoshop、Illustrator等全套软件。', 
+     '1. 访问adobe.com并登录您的Adobe账户\n2. 进入"账户"页面\n3. 点击"兑换代码"\n4. 输入激活码并点击"兑换"', 
+     3, 3, 3, NOW(), DATE_ADD(NOW(), INTERVAL 7 DAY), TRUE, FALSE, 3, NOW(), NOW());
+
+-- 初始CDK数据
+INSERT INTO cdk (activity_id, code, is_claimed, created_at)
+VALUES
+    -- JetBrains全家桶激活码
+    (1, 'JETB-RAIN-S123-4567', FALSE, NOW()),
+    (1, 'JETB-RAIN-S234-5678', FALSE, NOW()),
+    (1, 'JETB-RAIN-S345-6789', FALSE, NOW()),
+    (1, 'JETB-RAIN-S456-7890', FALSE, NOW()),
+    (1, 'JETB-RAIN-S567-8901', FALSE, NOW()),
+    (1, 'JETB-RAIN-S678-9012', FALSE, NOW()),
+    (1, 'JETB-RAIN-S789-0123', FALSE, NOW()),
+    (1, 'JETB-RAIN-S890-1234', FALSE, NOW()),
+    (1, 'JETB-RAIN-S901-2345', FALSE, NOW()),
+    (1, 'JETB-RAIN-S012-3456', FALSE, NOW()),
+    
+    -- Windows 11专业版激活码
+    (2, 'WIN11-PRO-1234-5678-9012', FALSE, NOW()),
+    (2, 'WIN11-PRO-2345-6789-0123', FALSE, NOW()),
+    (2, 'WIN11-PRO-3456-7890-1234', FALSE, NOW()),
+    (2, 'WIN11-PRO-4567-8901-2345', FALSE, NOW()),
+    (2, 'WIN11-PRO-5678-9012-3456', FALSE, NOW()),
+    
+    -- Adobe Creative Cloud会员
+    (3, 'ADOBE-CC-1234-5678-9012', FALSE, NOW()),
+    (3, 'ADOBE-CC-2345-6789-0123', FALSE, NOW()),
+    (3, 'ADOBE-CC-3456-7890-1234', FALSE, NOW());

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,73 @@
+-- 创建数据库
+CREATE DATABASE IF NOT EXISTS linuxdo_cdk DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+USE linuxdo_cdk;
+
+-- 用户表
+CREATE TABLE IF NOT EXISTS users (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    linux_do_id VARCHAR(50) NOT NULL UNIQUE COMMENT 'Linux.do用户ID',
+    username VARCHAR(50) NOT NULL COMMENT '用户名',
+    avatar VARCHAR(255) COMMENT '头像URL',
+    trust_level INT NOT NULL COMMENT '信任等级（1-3）',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    INDEX idx_linux_do_id (linux_do_id),
+    INDEX idx_trust_level (trust_level)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='用户表';
+
+-- CDK活动表
+CREATE TABLE IF NOT EXISTS cdk_activity (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(100) NOT NULL COMMENT '活动标题',
+    description TEXT COMMENT '活动描述',
+    usage_guide TEXT COMMENT '使用说明',
+    min_trust_level INT NOT NULL COMMENT '最低信任等级要求（1-3）',
+    total_count INT NOT NULL COMMENT 'CDK总数量',
+    remaining_count INT NOT NULL COMMENT '剩余数量',
+    start_time DATETIME NOT NULL COMMENT '开始时间',
+    end_time DATETIME NOT NULL COMMENT '结束时间',
+    is_active BOOLEAN NOT NULL DEFAULT TRUE COMMENT '是否激活',
+    is_public BOOLEAN NOT NULL DEFAULT TRUE COMMENT '是否公开',
+    creator_id BIGINT NOT NULL COMMENT '创建者ID',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '更新时间',
+    INDEX idx_creator_id (creator_id),
+    INDEX idx_is_active_public (is_active, is_public),
+    INDEX idx_start_end_time (start_time, end_time),
+    FOREIGN KEY (creator_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='CDK活动表';
+
+-- CDK表
+CREATE TABLE IF NOT EXISTS cdk (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    activity_id BIGINT NOT NULL COMMENT '关联的活动ID',
+    code VARCHAR(255) NOT NULL COMMENT 'CDK码',
+    is_claimed BOOLEAN NOT NULL DEFAULT FALSE COMMENT '是否已被领取',
+    claimed_by BIGINT COMMENT '领取者ID',
+    claimed_at DATETIME COMMENT '领取时间',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '创建时间',
+    INDEX idx_activity_id (activity_id),
+    INDEX idx_claimed_by (claimed_by),
+    INDEX idx_activity_claimed (activity_id, is_claimed),
+    FOREIGN KEY (activity_id) REFERENCES cdk_activity(id) ON DELETE CASCADE,
+    FOREIGN KEY (claimed_by) REFERENCES users(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='CDK表';
+
+-- 领取记录表
+CREATE TABLE IF NOT EXISTS claim_record (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id BIGINT NOT NULL COMMENT '用户ID',
+    activity_id BIGINT NOT NULL COMMENT '活动ID',
+    cdk_id BIGINT NOT NULL COMMENT 'CDK ID',
+    claimed_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '领取时间',
+    ip_address VARCHAR(50) COMMENT '领取IP地址',
+    INDEX idx_user_id (user_id),
+    INDEX idx_activity_id (activity_id),
+    INDEX idx_cdk_id (cdk_id),
+    INDEX idx_claimed_at (claimed_at),
+    UNIQUE INDEX idx_user_activity (user_id, activity_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (activity_id) REFERENCES cdk_activity(id) ON DELETE CASCADE,
+    FOREIGN KEY (cdk_id) REFERENCES cdk(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='领取记录表';


### PR DESCRIPTION
本次PR主要完成以下工作：

1. 移除了所有实体类中的Lombok注解，手动实现了所有的getter、setter、构造函数、equals、hashCode和toString方法
2. 移除了pom.xml中的Lombok依赖
3. 添加了完整的SQL文件，包括：
   - schema.sql：包含所有表结构的创建语句
   - data.sql：包含必要的初始数据

这些更改使得代码更加清晰，不依赖于Lombok的自动生成功能，同时提供了完整的数据库初始化脚本，方便部署和测试。

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author